### PR TITLE
feat: Update color scheme from purple to light blue

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,23 +8,23 @@ body {
 
 @layer base {
   :root {
-    --background: 240 67% 97%; /* Light Lavender */
-    --foreground: 275 100% 25%; /* Deep Indigo */
+    --background: 200 100% 97%; /* Lighter Blue */
+    --foreground: 200 100% 25%; /* Darker Blue */
 
-    --card: 240 60% 99%; /* Slightly whiter lavender */
-    --card-foreground: 275 100% 25%; /* Deep Indigo */
+    --card: 200 100% 99%; /* Slightly whiter blue */
+    --card-foreground: 200 100% 25%; /* Darker Blue */
 
-    --popover: 240 60% 99%; /* Slightly whiter lavender */
-    --popover-foreground: 275 100% 25%; /* Deep Indigo */
+    --popover: 200 100% 99%; /* Slightly whiter blue */
+    --popover-foreground: 200 100% 25%; /* Darker Blue */
 
-    --primary: 275 100% 25%; /* Deep Indigo */
-    --primary-foreground: 240 67% 97%; /* Light Lavender */
+    --primary: 200 100% 50%; /* Light Blue */
+    --primary-foreground: 200 100% 97%; /* Lighter Blue */
 
-    --secondary: 240 50% 92%; /* Lighter lavender for secondary elements */
-    --secondary-foreground: 275 80% 35%; /* Slightly lighter Indigo */
+    --secondary: 200 80% 92%; /* Lighter Blue variant */
+    --secondary-foreground: 200 100% 35%; /* Darker Blue variant */
 
-    --muted: 240 40% 88%; /* Muted lavender */
-    --muted-foreground: 275 60% 45%; /* Muted Indigo */
+    --muted: 200 70% 88%; /* Muted Blue */
+    --muted-foreground: 200 60% 45%; /* Muted Blue variant */
 
     --accent: 31 100% 50%; /* Sunset Orange */
     --accent-foreground: 0 0% 100%; /* White */
@@ -32,9 +32,9 @@ body {
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 240 30% 80%; /* Lavender-toned border */
-    --input: 240 30% 85%; /* Lavender-toned input background */
-    --ring: 31 100% 50%; /* Accent color for focus rings */
+    --border: 200 50% 80%; /* Blue-toned border */
+    --input: 200 50% 85%; /* Blue-toned input background */
+    --ring: 200 100% 50%; /* Light Blue */
 
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
@@ -43,34 +43,34 @@ body {
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
 
-    --sidebar-background: 275 100% 12%; /* Dark Indigo variant for sidebar */
-    --sidebar-foreground: 240 60% 90%; /* Light Lavender variant for sidebar text */
+    --sidebar-background: 200 100% 12%; /* Dark Blue variant */
+    --sidebar-foreground: 200 100% 90%; /* Lightest Blue */
     --sidebar-primary: 31 100% 55%; /* Sunset Orange for sidebar primary elements */
     --sidebar-primary-foreground: 0 0% 100%; /* White for text on sidebar primary */
-    --sidebar-accent: 275 80% 20%; /* Darker Indigo for sidebar accent */
-    --sidebar-accent-foreground: 240 60% 85%; /* Light Lavender for text on sidebar accent */
-    --sidebar-border: 275 70% 25%; /* Indigo-toned border for sidebar */
-    --sidebar-ring: 31 100% 50%; /* Sunset Orange for sidebar focus ring */
+    --sidebar-accent: 200 80% 20%; /* Darker Blue variant */
+    --sidebar-accent-foreground: 200 100% 85%; /* Lighter Blue */
+    --sidebar-border: 200 70% 25%; /* Blue-toned border */
+    --sidebar-ring: 200 100% 50%; /* Light Blue */
   }
 
   .dark {
-    --background: 275 100% 10%; /* Dark Indigo */
-    --foreground: 240 67% 90%; /* Light Lavenderish */
+    --background: 200 100% 10%; /* Dark Blue */
+    --foreground: 200 100% 90%; /* Lightest Blue */
 
-    --card: 275 90% 15%; /* Darker Indigo */
-    --card-foreground: 240 67% 90%; /* Light Lavenderish */
+    --card: 200 90% 15%; /* Darker Blue */
+    --card-foreground: 200 100% 90%; /* Lightest Blue */
 
-    --popover: 275 90% 12%; /* Darker Indigo */
-    --popover-foreground: 240 67% 90%; /* Light Lavenderish */
+    --popover: 200 90% 12%; /* Darker Blue */
+    --popover-foreground: 200 100% 90%; /* Lightest Blue */
 
-    --primary: 240 67% 85%; /* Bright Lavender */
-    --primary-foreground: 275 100% 15%; /* Dark Indigo */
+    --primary: 200 100% 85%; /* Bright Blue */
+    --primary-foreground: 200 100% 15%; /* Dark Blue */
     
-    --secondary: 275 70% 25%; /* Mid Indigo */
-    --secondary-foreground: 240 60% 80%; /* Lighter Lavenderish */
+    --secondary: 200 70% 25%; /* Mid Blue */
+    --secondary-foreground: 200 100% 80%; /* Lighter Blue */
 
-    --muted: 275 60% 30%; /* Muted Indigo */
-    --muted-foreground: 240 50% 70%; /* Muted Lavenderish */
+    --muted: 200 60% 30%; /* Muted Blue */
+    --muted-foreground: 200 80% 70%; /* Muted Light Blue */
 
     --accent: 31 100% 60%; /* Sunset Orange (brighter/adjusted for dark) */
     --accent-foreground: 275 100% 10%; /* Dark Indigo (for text on orange) */
@@ -78,9 +78,9 @@ body {
     --destructive: 0 70% 50%; /* Standard destructive red */
     --destructive-foreground: 0 0% 98%; /* Light text for destructive */
 
-    --border: 275 70% 25%; /* Indigo-toned border */
-    --input: 275 70% 20%; /* Indigo-toned input background */
-    --ring: 31 100% 60%; /* Sunset Orange for focus rings */
+    --border: 200 70% 25%; /* Blue-toned border */
+    --input: 200 70% 20%; /* Blue-toned input background */
+    --ring: 200 100% 60%; /* Bright Blue */
 
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
@@ -88,14 +88,14 @@ body {
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
 
-    --sidebar-background: 275 100% 8%; 
-    --sidebar-foreground: 240 67% 88%;
+    --sidebar-background: 200 100% 8%; /* Darkest Blue */
+    --sidebar-foreground: 200 100% 88%; /* Light Blue */
     --sidebar-primary: 31 100% 65%;
     --sidebar-primary-foreground: 275 100% 5%;
-    --sidebar-accent: 275 80% 18%;
-    --sidebar-accent-foreground: 240 67% 80%;
-    --sidebar-border: 275 70% 22%;
-    --sidebar-ring: 31 100% 60%;
+    --sidebar-accent: 200 80% 18%; /* Darker Blue variant */
+    --sidebar-accent-foreground: 200 100% 80%; /* Lighter Blue */
+    --sidebar-border: 200 70% 22%; /* Blue-toned border */
+    --sidebar-ring: 200 100% 60%; /* Bright Blue */
   }
 }
 


### PR DESCRIPTION
This commit updates the website's color scheme from various shades of purple (lavender, indigo) to a new light blue theme.

The following changes were made:
- Defined a new set of HSL values for light blue shades.
- Updated CSS variables in `src/app/globals.css` for both light and dark themes to use the new blue color palette.
- This includes changes to background, foreground, card, popover, primary, secondary, muted, border, input, and ring colors.
- Sidebar-specific colors were also updated to match the new blue theme.
- Accent (Sunset Orange) and destructive (Red) colors remain unchanged to maintain necessary UI contrast.